### PR TITLE
Update 2017-09-27-BaggingVsBoosting.md

### DIFF
--- a/_posts/2017-09-27-BaggingVsBoosting.md
+++ b/_posts/2017-09-27-BaggingVsBoosting.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Classificadores Ensemble, tipos Bagging e Boosting
+title: Classificadores Ensemble&#58; Bagging e Boosting
 lang: pt
 header-img: img/0026.png
 date: 2017-09-27 14:15:07


### PR DESCRIPTION
A autora original do post deu o titulo com o caractere ":" porém isso bugava o jekyll que usa esse simbolo como parsing do cabeçalho, por isso na época alterei para ", tipos" encontrei hoje a solução pra isso e me lembrei desse problema, por isso vim corrigi-lo e apresentar essa sugestão para os próximos.